### PR TITLE
timeout in seconds to generate/chat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ollamar
 Title: 'Ollama' Language Models
-Version: 1.2.2.9000
+Version: 1.2.2-01
 Authors@R: c( 
     person("Hause", "Lin", , "hauselin@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-4590-7039")),
@@ -14,7 +14,7 @@ License: MIT + file LICENSE
 Depends: R (>= 4.1)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Description: An interface to easily run local language models with 'Ollama' <htt
     and API endpoints (see <https://github.com/ollama/ollama/blob/main/docs/api.md> for details). It lets 
     you run open-source large language models locally on your machine. 
 License: MIT + file LICENSE
+Depends: R (>= 4.1)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/ollama.R
+++ b/R/ollama.R
@@ -41,7 +41,8 @@ create_request <- function(endpoint, host = NULL,
         user_agent = package_config$user_agent
     )
     req <- httr2::req_headers(req, !!!headers) |>
-       httr2::req_options(timeout_ms = timeout*1000)
+       httr2::req_options(timeout_ms = timeout*1000,
+                          low_speed_limit = 0)
     return(req)
 }
 
@@ -80,6 +81,7 @@ create_request <- function(endpoint, host = NULL,
 #' [API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion)
 #'
 #' @examplesIf test_connection(logical = TRUE)
+#' ooptions <- options(timeout = 1200)
 #' # text prompt
 #' generate("llama3", "The sky is...", stream = FALSE, output = "df")
 #' # stream and increase temperature
@@ -89,7 +91,9 @@ create_request <- function(endpoint, host = NULL,
 #' # something like "image1.png"
 #' image_path <- file.path(system.file("extdata", package = "ollamar"), "image1.png")
 #' # use vision or multimodal model such as https://ollama.com/benzie/llava-phi-3
-#' generate("benzie/llava-phi-3:latest", "What is in the image?", images = image_path, output = "text")
+#' generate("benzie/llava-phi-3:latest", "What is in the image?", images = image_path,
+#'           output = "text")
+#' options(ooptions)
 generate <- function(model, prompt, suffix = "", images = "", format = list(), system = "",
                      template = "", context = list(), stream = FALSE, raw = FALSE,
                      keep_alive = "5m",
@@ -328,7 +332,7 @@ chat <- function(model, messages, tools = list(), stream = FALSE, format = list(
 #' model_avail("mario") # check mario model has been created
 #' list_models() # mario model has been created
 #' generate("mario", "who are you?", output = "text",
-#'           timeout = 300)  # model should say it's Mario
+#'           timeout = 600)  # model should say it's Mario
 #' delete("mario") # delete the model created above
 #' model_avail("mario") # model no longer exists
 create <- function(model, from, system = NULL, stream = FALSE, endpoint = "/api/create", host = NULL) {

--- a/R/ollama.R
+++ b/R/ollama.R
@@ -16,6 +16,7 @@ package_config <- list(
 #'
 #' @param endpoint The endpoint to create the request
 #' @param host The base URL to use. Default is NULL, which uses http://127.0.0.1:11434
+#' @param timeout The httr2 request timeout, in seconds.  Defaults to 'options()$timeout)'.
 #'
 #' @return A httr2 request object.
 #' @export
@@ -23,8 +24,9 @@ package_config <- list(
 #' @examples
 #' create_request("/api/tags")
 #' create_request("/api/chat")
-#' create_request("/api/embeddings")
-create_request <- function(endpoint, host = NULL) {
+#' create_request("/api/embeddings", timeout = 20)
+create_request <- function(endpoint, host = NULL,
+                           timeout = options()$timeout) {
     if (is.null(host)) {
         url <- package_config$baseurls[1] # use default base URL
     } else {
@@ -38,11 +40,10 @@ create_request <- function(endpoint, host = NULL) {
         accept = "application/json",
         user_agent = package_config$user_agent
     )
-    req <- httr2::req_headers(req, !!!headers)
+    req <- httr2::req_headers(req, !!!headers) |>
+       httr2::req_options(timeout_ms = timeout*1000)
     return(req)
 }
-
-
 
 
 
@@ -65,6 +66,8 @@ create_request <- function(endpoint, host = NULL) {
 #' @param stream Enable response streaming. Default is FALSE.
 #' @param raw If TRUE, no formatting will be applied to the prompt. You may choose to use the raw parameter if you are specifying a full templated prompt in your request to the API. Default is FALSE.
 #' @param keep_alive The time to keep the connection alive. Default is "5m" (5 minutes).
+#' @param timeout The POST request timeout, in seconds.  Defaults to 'options()$timeout'.  A complex task can easily
+#'   take hours on slower computers.
 #' @param output A character vector of the output format. Default is "resp". Options are "resp", "jsonlist", "raw", "df", "text", "req" (httr2_request object).
 #' @param endpoint The endpoint to generate the completion. Default is "/api/generate".
 #' @param host The base URL to use. Default is NULL, which uses Ollama's default base URL.
@@ -87,13 +90,18 @@ create_request <- function(endpoint, host = NULL) {
 #' image_path <- file.path(system.file("extdata", package = "ollamar"), "image1.png")
 #' # use vision or multimodal model such as https://ollama.com/benzie/llava-phi-3
 #' generate("benzie/llava-phi-3:latest", "What is in the image?", images = image_path, output = "text")
-generate <- function(model, prompt, suffix = "", images = "", format = list(), system = "", template = "", context = list(), stream = FALSE, raw = FALSE, keep_alive = "5m", output = c("resp", "jsonlist", "raw", "df", "text", "req", "structured"), endpoint = "/api/generate", host = NULL, ...) {
+generate <- function(model, prompt, suffix = "", images = "", format = list(), system = "",
+                     template = "", context = list(), stream = FALSE, raw = FALSE,
+                     keep_alive = "5m",
+                     timeout = options()$timeout,
+                     output = c("resp", "jsonlist", "raw", "df", "text", "req", "structured"),
+                     endpoint = "/api/generate", host = NULL,
+                     ...) {
     output <- output[1]
     if (!output %in% c("df", "resp", "jsonlist", "raw", "text", "req", "structured")) {
         stop("Invalid output format specified. Supported formats: 'df', 'resp', 'jsonlist', 'raw', 'text', 'req', 'structured'")
     }
-
-    req <- create_request(endpoint, host)
+    req <- create_request(endpoint, host, timeout = timeout)
     req <- httr2::req_method(req, "POST")
 
     images_list <- list()
@@ -177,6 +185,8 @@ generate <- function(model, prompt, suffix = "", images = "", format = list(), s
 #' @param stream Enable response streaming. Default is FALSE.
 #' @param format Format to return a response in. Format can be json/list (structured response).
 #' @param keep_alive The duration to keep the connection alive. Default is "5m".
+#' @param timeout The POST request timeout, in seconds.  Defaults to 'options()$timeout'.
+#'   A multiple-message task can take long time on a slow computer or with a large model.
 #' @param output The output format. Default is "resp". Other options are "jsonlist", "raw", "df", "text", "req" (httr2_request object), "tools" (tool calling), "structured" (structured output)
 #' @param endpoint The endpoint to chat with the model. Default is "/api/chat".
 #' @param host The base URL to use. Default is NULL, which uses Ollama's default base URL.
@@ -193,6 +203,7 @@ generate <- function(model, prompt, suffix = "", images = "", format = list(), s
 #' messages <- list(
 #'     list(role = "user", content = "How are you doing?")
 #' )
+#' otimeout <- options(timeout = 300)  # longer timeout for all following examples
 #' chat("llama3", messages) # returns response by default
 #' chat("llama3", messages, output = "text") # returns text/vector
 #' chat("llama3", messages, temperature = 2.8) # additional options
@@ -214,14 +225,18 @@ generate <- function(model, prompt, suffix = "", images = "", format = list(), s
 #' messages <- list(
 #'     list(role = "user", content = "What is in the image?", images = image_path)
 #' )
-#' chat("benzie/llava-phi-3", messages, output = "text")
-chat <- function(model, messages, tools = list(), stream = FALSE, format = list(), keep_alive = "5m", output = c("resp", "jsonlist", "raw", "df", "text", "req", "tools", "structured"), endpoint = "/api/chat", host = NULL, ...) {
+#' chat("benzie/llava-phi-3", messages, output = "text", timeout = 600)
+#' options(otimeout)  # restore the original timeout
+chat <- function(model, messages, tools = list(), stream = FALSE, format = list(),
+                 keep_alive = "5m",
+                 timeout = options()$timeout,
+                 output = c("resp", "jsonlist", "raw", "df", "text", "req", "tools", "structured"), endpoint = "/api/chat", host = NULL, ...) {
     output <- output[1]
     if (!output %in% c("df", "resp", "jsonlist", "raw", "text", "req", "tools", "structured")) {
         stop("Invalid output format specified. Supported formats: 'df', 'resp', 'jsonlist', 'raw', 'text', 'tools', 'structured'")
     }
 
-    req <- create_request(endpoint, host)
+    req <- create_request(endpoint, host, timeout)
     req <- httr2::req_method(req, "POST")
 
     if (!validate_messages(messages)) {
@@ -312,7 +327,8 @@ chat <- function(model, messages, tools = list(), stream = FALSE, format = list(
 #' create("mario", "deepseek-r1:1.5b", system = "You are Mario from Super Mario Bros.")
 #' model_avail("mario") # check mario model has been created
 #' list_models() # mario model has been created
-#' generate("mario", "who are you?", output = "text") # model should say it's Mario
+#' generate("mario", "who are you?", output = "text",
+#'           timeout = 300)  # model should say it's Mario
 #' delete("mario") # delete the model created above
 #' model_avail("mario") # model no longer exists
 create <- function(model, from, system = NULL, stream = FALSE, endpoint = "/api/create", host = NULL) {

--- a/man/chat.Rd
+++ b/man/chat.Rd
@@ -11,6 +11,7 @@ chat(
   stream = FALSE,
   format = list(),
   keep_alive = "5m",
+  timeout = options()$timeout,
   output = c("resp", "jsonlist", "raw", "df", "text", "req", "tools", "structured"),
   endpoint = "/api/chat",
   host = NULL,
@@ -29,6 +30,9 @@ chat(
 \item{format}{Format to return a response in. Format can be json/list (structured response).}
 
 \item{keep_alive}{The duration to keep the connection alive. Default is "5m".}
+
+\item{timeout}{The POST request timeout, in seconds.  Defaults to 'options()$timeout'.
+A multiple-message task can take long time on a slow computer or with a large model.}
 
 \item{output}{The output format. Default is "resp". Other options are "jsonlist", "raw", "df", "text", "req" (httr2_request object), "tools" (tool calling), "structured" (structured output)}
 
@@ -50,6 +54,7 @@ Generate a chat completion with message history
 messages <- list(
     list(role = "user", content = "How are you doing?")
 )
+otimeout <- options(timeout = 300)  # longer timeout for all following examples
 chat("llama3", messages) # returns response by default
 chat("llama3", messages, output = "text") # returns text/vector
 chat("llama3", messages, temperature = 2.8) # additional options
@@ -71,7 +76,8 @@ image_path <- file.path(system.file("extdata", package = "ollamar"), "image1.png
 messages <- list(
     list(role = "user", content = "What is in the image?", images = image_path)
 )
-chat("benzie/llava-phi-3", messages, output = "text")
+chat("benzie/llava-phi-3", messages, output = "text", timeout = 600)
+options(otimeout)  # restore the original timeout
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/chat.Rd
+++ b/man/chat.Rd
@@ -49,7 +49,7 @@ A response in the format specified in the output parameter.
 Generate a chat completion with message history
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 # one message
 messages <- list(
     list(role = "user", content = "How are you doing?")

--- a/man/copy.Rd
+++ b/man/copy.Rd
@@ -22,7 +22,7 @@ A httr2 response object.
 Creates a model with another name from an existing model.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 copy("llama3", "llama3_copy")
 delete("llama3_copy") # delete the model was just got copied
 \dontshow{\}) # examplesIf}

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -33,12 +33,12 @@ A response in the format specified in the output parameter.
 Create a model from another model, a safetensors directory (not implemented), or a GGUF file (not implemented).
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 create("mario", "deepseek-r1:1.5b", system = "You are Mario from Super Mario Bros.")
 model_avail("mario") # check mario model has been created
 list_models() # mario model has been created
 generate("mario", "who are you?", output = "text",
-          timeout = 300)  # model should say it's Mario
+          timeout = 600)  # model should say it's Mario
 delete("mario") # delete the model created above
 model_avail("mario") # model no longer exists
 \dontshow{\}) # examplesIf}

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -37,7 +37,8 @@ Create a model from another model, a safetensors directory (not implemented), or
 create("mario", "deepseek-r1:1.5b", system = "You are Mario from Super Mario Bros.")
 model_avail("mario") # check mario model has been created
 list_models() # mario model has been created
-generate("mario", "who are you?", output = "text") # model should say it's Mario
+generate("mario", "who are you?", output = "text",
+          timeout = 300)  # model should say it's Mario
 delete("mario") # delete the model created above
 model_avail("mario") # model no longer exists
 \dontshow{\}) # examplesIf}

--- a/man/create_request.Rd
+++ b/man/create_request.Rd
@@ -4,12 +4,14 @@
 \alias{create_request}
 \title{Create a httr2 request object}
 \usage{
-create_request(endpoint, host = NULL)
+create_request(endpoint, host = NULL, timeout = options()$timeout)
 }
 \arguments{
 \item{endpoint}{The endpoint to create the request}
 
 \item{host}{The base URL to use. Default is NULL, which uses http://127.0.0.1:11434}
+
+\item{timeout}{The httr2 request timeout, in seconds.  Defaults to 'options()$timeout)'.}
 }
 \value{
 A httr2 request object.
@@ -20,5 +22,5 @@ Creates a httr2 request object with base URL, headers and endpoint. Used by othe
 \examples{
 create_request("/api/tags")
 create_request("/api/chat")
-create_request("/api/embeddings")
+create_request("/api/embeddings", timeout = 20)
 }

--- a/man/embed.Rd
+++ b/man/embed.Rd
@@ -39,7 +39,7 @@ A numeric matrix of the embedding. Each column is the embedding for one input.
 Supercedes the \code{embeddings()} function.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 embed("nomic-embed-text:latest", "The quick brown fox jumps over the lazy dog.")
 # pass multiple inputs
 embed("nomic-embed-text:latest", c("Good bye", "Bye", "See you."))

--- a/man/embeddings.Rd
+++ b/man/embeddings.Rd
@@ -36,7 +36,7 @@ A numeric vector of the embedding.
 This function will be deprecated over time and has been superceded by \code{embed()}. See \code{embed()} for more details.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 embeddings("nomic-embed-text:latest", "The quick brown fox jumps over the lazy dog.")
 # pass model options to the model
 embeddings("nomic-embed-text:latest", "Hello!", temperature = 0.1, num_predict = 3)

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -16,6 +16,7 @@ generate(
   stream = FALSE,
   raw = FALSE,
   keep_alive = "5m",
+  timeout = options()$timeout,
   output = c("resp", "jsonlist", "raw", "df", "text", "req", "structured"),
   endpoint = "/api/generate",
   host = NULL,
@@ -44,6 +45,9 @@ generate(
 \item{raw}{If TRUE, no formatting will be applied to the prompt. You may choose to use the raw parameter if you are specifying a full templated prompt in your request to the API. Default is FALSE.}
 
 \item{keep_alive}{The time to keep the connection alive. Default is "5m" (5 minutes).}
+
+\item{timeout}{The POST request timeout, in seconds.  Defaults to 'options()$timeout'.  A complex task can easily
+take hours on slower computers.}
 
 \item{output}{A character vector of the output format. Default is "resp". Options are "resp", "jsonlist", "raw", "df", "text", "req" (httr2_request object).}
 

--- a/man/generate.Rd
+++ b/man/generate.Rd
@@ -64,7 +64,8 @@ A response in the format specified in the output parameter.
 Generate a response for a given prompt
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
+ooptions <- options(timeout = 1200)
 # text prompt
 generate("llama3", "The sky is...", stream = FALSE, output = "df")
 # stream and increase temperature
@@ -74,7 +75,9 @@ generate("llama3", "The sky is...", stream = TRUE, output = "text", temperature 
 # something like "image1.png"
 image_path <- file.path(system.file("extdata", package = "ollamar"), "image1.png")
 # use vision or multimodal model such as https://ollama.com/benzie/llava-phi-3
-generate("benzie/llava-phi-3:latest", "What is in the image?", images = image_path, output = "text")
+generate("benzie/llava-phi-3:latest", "What is in the image?", images = image_path,
+          output = "text")
+options(ooptions)
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/list_models.Rd
+++ b/man/list_models.Rd
@@ -24,7 +24,7 @@ A response in the format specified in the output parameter.
 List models that are available locally
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 list_models() # returns dataframe
 list_models("df") # returns dataframe
 list_models("resp") # httr2 response object

--- a/man/model_avail.Rd
+++ b/man/model_avail.Rd
@@ -16,7 +16,7 @@ A logical value indicating if the model exists.
 Check if model is available locally
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 model_avail("codegemma:7b")
 model_avail("abc")
 model_avail("llama3")

--- a/man/ohelp.Rd
+++ b/man/ohelp.Rd
@@ -18,7 +18,7 @@ Does not return anything. It prints the conversation in the console.
 Chat with a model in real-time in R console
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 ohelp(first_prompt = "quit")
 # regular usage: ohelp()
 \dontshow{\}) # examplesIf}

--- a/man/ps.Rd
+++ b/man/ps.Rd
@@ -24,7 +24,7 @@ A response in the format specified in the output parameter.
 List models that are currently loaded into memory
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 ps("text")
 \dontshow{\}) # examplesIf}
 }

--- a/man/pull.Rd
+++ b/man/pull.Rd
@@ -30,7 +30,7 @@ A httr2 response object.
 See https://ollama.com/library for a list of available models. Use the list_models() function to get the list of models already downloaded/installed on your machine. Cancelled pulls are resumed from where they left off, and multiple calls will share the same download progress.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 pull("llama3")
 pull("all-minilm", stream = FALSE)
 \dontshow{\}) # examplesIf}

--- a/man/push.Rd
+++ b/man/push.Rd
@@ -33,7 +33,7 @@ A httr2 response object.
 Push or upload a model to an Ollama model library. Requires registering for ollama.ai and adding a public key first.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 push("mattw/pygmalion:latest")
 \dontshow{\}) # examplesIf}
 }

--- a/man/resp_process.Rd
+++ b/man/resp_process.Rd
@@ -21,7 +21,7 @@ A data frame, json list, raw or httr2 response object.
 Process httr2 response object
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 resp <- list_models("resp")
 resp_process(resp, "df") # parse response to dataframe/tibble
 resp_process(resp, "jsonlist") # parse response to list

--- a/man/show.Rd
+++ b/man/show.Rd
@@ -30,7 +30,7 @@ A response in the format specified in the output parameter.
 Model information includes details, modelfile, template, parameters, license, system prompt.
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 # show("llama3") # returns jsonlist
 show("llama3", output = "resp") # returns response object
 \dontshow{\}) # examplesIf}

--- a/man/ver.Rd
+++ b/man/ver.Rd
@@ -18,7 +18,7 @@ A character string of the Ollama version.
 Retrieve Ollama version
 }
 \examples{
-\dontshow{if (test_connection(logical = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (test_connection(logical = TRUE)) withAutoprint(\{ # examplesIf}
 ver()
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-chat.R
+++ b/tests/testthat/test-chat.R
@@ -8,6 +8,8 @@ test_that("chat function works with basic input", {
         list(role = "user", content = "Tell me a 5-word story.")
     )
 
+    ooptions <- options(timeout = 600)  # set it for all calls
+
     # incorrect output type
     expect_error(chat("llama3", messages, output = "abc"))
 
@@ -53,6 +55,8 @@ test_that("chat function works with basic input", {
     expect_true(all(c("model", "role", "content", "created_at") %in% names(result)))
     expect_equal(result$model[1], "llama3")
     expect_equal(result$role[1], "assistant")
+
+    options(ooptions)
 })
 
 test_that("chat function handles streaming correctly", {
@@ -105,6 +109,8 @@ test_that("chat function handles images in messages", {
     skip_if_not(test_connection(logical = TRUE), "Ollama server not available")
     skip_if_not(model_avail("benzie/llava-phi-3"), "benzie/llava-phi-3 model not available")
 
+    ooptions <- options(timeout = 600)
+    
     images <- c(file.path(system.file("extdata", package = "ollamar"), "image1.png"),
                 file.path(system.file("extdata", package = "ollamar"), "image2.png"))
 
@@ -128,12 +134,15 @@ test_that("chat function handles images in messages", {
     expect_type(result, "character")
     # expect_true(grepl("melon", tolower(result)) | grepl("cam", tolower(result)))
 
+    options(ooptions)
 })
 
 
 test_that("chat function tool calling", {
     skip_if_not(test_connection(logical = TRUE), "Ollama server not available")
 
+    ooptions <- options(timeout = 600)
+    
     add_two_numbers <- function(x, y) {
         return(x + y)
     }
@@ -234,6 +243,7 @@ test_that("chat function tool calling", {
     # expect_equal(resp[[1]]$name, "add_two_numbers")
     # expect_equal(resp[[2]]$name, "multiply_two_numbers")
 
+    options(ooptions)
 })
 
 
@@ -242,6 +252,8 @@ test_that("chat function tool calling", {
 test_that("structured output", {
     skip_if_not(test_connection(logical = TRUE), "Ollama server not available")
 
+    ooptions <- options(timeout = 600)  # set it for all calls
+    
     format <- list(
         type = "object",
         properties = list(
@@ -266,6 +278,8 @@ test_that("structured output", {
     # content <- httr2::resp_body_json(resp)$message$content
     structured_output <- resp_process(resp, "structured")
     expect_equal(tolower(structured_output$name), "canada")
+
+    options(ooptions)
 
 })
 

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -4,10 +4,13 @@ library(ollamar)
 test_that("generate function works with different outputs and resp_process", {
     skip_if_not(test_connection(logical = TRUE), "Ollama server not available")
 
+    ooptions <- options(timeout = 600)
+    
     # incorrect output type
     expect_error(generate("llama3", "The sky is...", output = "abc"))
 
-    expect_s3_class(generate("llama3.1", "tell me a 5-word story", output = "req"), "httr2_request")
+    expect_s3_class(generate("llama3.1", "tell me a 5-word story",
+                             output = "req", timeout = 600), "httr2_request")
 
     # not streaming
     expect_s3_class(generate("llama3", "The sky is..."), "httr2_response")
@@ -43,6 +46,8 @@ test_that("generate function works with different outputs and resp_process", {
     expect_type(resp_process(result, "jsonlist"), "list")
     expect_type(resp_process(result, "text"), "character")
     expect_type(resp_process(result, "raw"), "character")
+
+    options(ooptions)
 })
 
 test_that("generate function works with additional options", {
@@ -60,7 +65,8 @@ test_that("generate function works with images", {
 
     image_path <- file.path(system.file("extdata", package = "ollamar"), "image1.png")
 
-    result <- generate("benzie/llava-phi-3", "What is in the image?", images = image_path)
+    result <- generate("benzie/llava-phi-3", "What is in the image?", images = image_path,
+                       timeout = 600)
     expect_s3_class(result, "httr2_response")
     expect_type(resp_process(result, "text"), "character")
     expect_match(tolower(resp_process(result, "text")), "watermelon")
@@ -72,7 +78,8 @@ test_that("generate function works with images", {
 
     # multiple images
     result <- generate("benzie/llava-phi-3", "What objects are in the two images?",
-                       images = images, output = 'text')
+                       images = images, output = 'text',
+                       timeout = 600)
     expect_type(result, "character")
     expect_true(grepl("melon", tolower(result)) | grepl("cam", tolower(result)))
 
@@ -105,7 +112,8 @@ test_that("structured output", {
     )
 
     msg <- "tell me about canada"
-    resp <- generate("llama3.1:8b", prompt = msg, format = format)
+    resp <- generate("llama3.1:8b", prompt = msg, format = format,
+                     timeout = 600)
     # response <- httr2::resp_body_json(resp)$response
     structured_output <- resp_process(resp, "structured")
     expect_equal(tolower(structured_output$name), "canada")

--- a/tests/testthat/test-ps.R
+++ b/tests/testthat/test-ps.R
@@ -5,7 +5,7 @@ test_that("ps list running models endpoint", {
     skip_if_not(test_connection(logical = TRUE), "Ollama server not available")
 
     # load models first
-    g1 <- generate('llama3', "tell me a 5 word story")
+    g1 <- generate('llama3', "tell me a 5 word story", timeout = 600)
 
     result <- ps()
     expect_true(nrow(result) >= 1)


### PR DESCRIPTION
These are the changes that include `timeout =` option for `generate()` and `chat()`.  I also added a few timeouts to the tests, as it otherwise failed on my slow computer.  Please be aware that it is not ready to be accepted--just to review and discussion.

**Brief description**

The communication with _ollama_ goes through _httr2_ requests.  _httr2_, in turn, uses _curl_, and _curl_ has its own timeouts.  See `curl::curl_options()`.  `timeout_ms` seems to be the relevant one here.  I added the timeout option to `create_request()`, that `generate()` and `chat()` use.

**Topics to discuss:**

* what does `keep_alive` do: can it somehow be used for request timeouts?
* what is a good API for timeouts?  Currently added `timeout = <seconds>` right after `keep_alive`.  Would be nice to have it not just seconds but like `10` for 10s, `5m` for 5 mins, `3h` for 3 hours etc.  But not a major issue.
* there should be some kind of consistency checking: timeout should be a non-zero number.  Throw an error otherwise.
* what is a good default value?  Currently I used `options()$timeout`.
* how to implement it internally?  I used R 4.1 pipe `|>`.  This means the package is not compatible with R < 4.1.  Is this a good idea?
* which functions need it?  Currently only added to `generate()` and `chat()` as those were the ones that failed for me.
* what is a good way to add it to examples/tests?  Currently added `options(timeout = 600)` to many examples, so that the old test computer passed all tests.

There may be more.

On the positive side: got some image tasks done on my 2011 laptop that took 2.5h :-)